### PR TITLE
新規データ追加 - NotifyInsertItem を使用するよう変更

### DIFF
--- a/BlazorServerDataGridSample/Pages/Index.razor
+++ b/BlazorServerDataGridSample/Pages/Index.razor
@@ -319,8 +319,6 @@
         message = "";
         errorMessage = "";
 
-        var tempDetails = new List<SalesDetailViewModel>(_salesDetails);
-
         var newRow = new SalesDetailViewModel();
         newRow.SlipNumber = SlipNumber;
         newRow.RowNumber = RowNumber;
@@ -331,13 +329,10 @@
         newRow.Amount = Amount;
         newRow.SalesTax = SalesTax;
 
-        tempDetails.Add(newRow);
-
-        _salesDetails = tempDetails;
+        _salesDetails.Add(newRow);
 
         RowNumber++;
-
-        this.StateHasChanged();
+        _grid?.NotifyInsertItem(_salesDetails, RowNumber, newRow);
     }
 
     //明細データの更新処理


### PR DESCRIPTION
IgbGrid に変更を検知させるために、データソースオブジェクトの参照 (アドレス) を変更すべく、Sales Data のリストを複製して、その複製後のリストにデータソースを差し替えるのは、サイズも僅かで一時的とはいえメモリと処理時間も効率的にもあまり好ましくないと考えられました。

加えて、データソースを複製して差し替えだと、実行するたびに、IgbGrid が全行 DOM を再構築するため、IgbGrid 内のスクロール位置が常に一番上に巻き戻ってしまう、という挙動も発生します。

幸い、IgbGrid にはそもそもこのようなシナリオを想定し、`Notify～` で始まる名前の変更通知用の各種メソッドが用意されています。
ということで、新規データ追加時は `NotifyInsertItem` メソッドを使用し、Sales Data のリストの重複複製を回避するようにしました。