### PR TITLE
明細データ更新時のデータマッピングを LINQ 化

### DIFF
--- a/BlazorServerDataGridSample/Pages/Index.razor
+++ b/BlazorServerDataGridSample/Pages/Index.razor
@@ -355,15 +355,11 @@
 
         // Mapperを作成
         var mapper = config.CreateMapper();
-        // UserViewModelのデータがUserの型でマッピングされる
-        List<SalesDetail> salesData = new();
 
-        foreach (var item in _salesDetails)
-        {
-            var sale = mapper.Map<SalesDetail>(item);
-            salesData.Add(sale);
-        }
-
+        // SalesDetailViewModelのデータがSalesDetailの型でマッピングされる
+        var salesData = _salesDetails
+            .Select(mapper.Map<SalesDetail>)
+            .ToList();
 
         try
         {


### PR DESCRIPTION
当初は `List<SalesDetail> salesData = new();` を `var salesData = new List<SalesDetail>();` として頂きたいという変更プルリクエストを送らせて頂くつもりでした。(ちなみに、右辺値での new の型推論は、左辺値で型推論できない場合、すなわち、フィールドやプロパティの初期化などの場面に限定して使うべきだろう、という議論・合意を Reddit などでも目撃しております。また、ASP.NET Core 開発チームのソースコードもそういうコーディングスタイルになっているようです)

ということでコード変更に着手したのですが、よくコードを読んでみるとこれは ViewModel から Model への変換なのですね。このような "変換" のために、`foreach` でループしながら `List<T>` に詰め込み直す処理は頻出しますが、このようなデータ変換には、以下の理由から LINQ で実装することが推奨されます。

- コードの意図が明確になる (`Select` ならば射影・マッピングであるとすぐに汲み取れる / `foreach` ループは汎用に過ぎてループの中を読まないと意図がすぐに汲み取れない)
- ローカル変数が増えない (LINQ ではラムダ式内という局所的スコープに変数を閉じ込められる)

これは LINQ に限らず、JavaScript プログラミングにおいても上記と同じ理由から、`map`、`filter`、`reduce` などのコレクション操作のメソッド使用が推奨されることと思います。

以上を踏まえて、このプルリクエストを送信させて頂きます。