### PR TITLE
初期データが空の場合に伝票番号の最大値取得で例外になる不具合修正

### DIFF
--- a/BlazorServerDataGridSample/Pages/Index.razor
+++ b/BlazorServerDataGridSample/Pages/Index.razor
@@ -82,6 +82,7 @@
 
             <IgbGrid Data="_salesDetails"
                  Height="600px"
+                 AutoGenerate="false"
                  ValidationStatusChange="OnValidationStatusChange"
                  CellEdit="OnCellEdit"
                  CellEditEnter="OnCellEditEnter"
@@ -389,7 +390,7 @@
         _salesDetails = SalesDetailService.GetDispAll().ToList();
 
         //伝票番号の最大値
-        SlipNumber = _salesDetails.Max(n => n.SlipNumber) + 1;
+        SlipNumber = _salesDetails.Select(n => n.SlipNumber).DefaultIfEmpty(0).Max() + 1;
 
         //数量、単価初期値
         this.Quantity = 12;


### PR DESCRIPTION
空の集合に対して LINQ の `Max()` を呼び出すと、`InvalidOperationException` 例外が発生します。集合が空の場合に備えて、`DefaultIfEmpty<T>()` で既定値の要素を必ず1つ返るようにしてから `Max()` で最大値を取るようにしました。

なお、初期データが空の状態で新規データ追加すると、IgbGrid の列レイアウトが崩れるという現象も発生しました。確認しましたところ、IgbGrid に対して `AutoGenerate`  が未設定、すなわち既定値の `true` になっていたかと思います。これを明示的に `false` に設定することで、この不具合も修正されました。