### PR TITLE
新規行追加用フォームを EditForm を使用するよう改訂、入力検証も実装

### DIFF
--- a/BlazorServerDataGridSample/Data/ViewModels/SalesDetailViewModel.cs
+++ b/BlazorServerDataGridSample/Data/ViewModels/SalesDetailViewModel.cs
@@ -1,32 +1,30 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Xml.Linq;
+using AutoMapper;
 
 namespace BlazorServerDataGridSample.Data.ViewModels
 {
-
-
     [CustomValidation(typeof(SalesDetailViewModel), "SalesDetailCheck")]
     public class SalesDetailViewModel
     {
         [Display(Name = "Id")]
         public int Id { get; set; }
 
-        [Display(Name = "伝票番号")]
+        [Display(Name = "伝票番号"), Range(1, 9999, ErrorMessage = "伝票番号は 1～9999 で指定してください")]
         public int SlipNumber { get; set; }
 
-        [Display(Name = "行番号")]
+        [Display(Name = "行番号"), Range(1, int.MaxValue, ErrorMessage = "行番号は 1 以上を指定してください")]
         public int RowNumber { get; set; }
 
-        [Display(Name = "商品コード")]
+        [Display(Name = "商品コード"), Required(ErrorMessage = "商品コードを入力してください"), StringLength(10, ErrorMessage = "商品コードは 10 文字までです")]
         public string ItemCode { get; set; } = "";
 
-        [Display(Name = "商品名")]
+        [Display(Name = "商品名"), Required(ErrorMessage = "商品名を入力してください"), StringLength(10, ErrorMessage = "商品名は 10 文字までです")]
         public string ItemName { get; set; } = "";
 
-        [Display(Name = "数量")]
+        [Display(Name = "数量"), Range(0, int.MaxValue, ErrorMessage = "数量は 0 以上を指定してください")]
         public decimal Quantity { get; set; }
 
-        [Display(Name = "単価")]
+        [Display(Name = "単価"), Range(0, int.MaxValue, ErrorMessage = "単価は 0 以上を指定してください")]
         public decimal UnitPrice { get; set; }
 
         [Display(Name = "金額")]
@@ -46,6 +44,11 @@ namespace BlazorServerDataGridSample.Data.ViewModels
             return ValidationResult.Success;
         }
 
+        private static readonly IMapper Mapper = new MapperConfiguration(cfg => cfg.CreateMap<SalesDetailViewModel, SalesDetailViewModel>()).CreateMapper();
 
+        public SalesDetailViewModel Clone()
+        {
+            return Mapper.Map<SalesDetailViewModel>(this);
+        }
     }
 }

--- a/BlazorServerDataGridSample/Pages/Index.razor
+++ b/BlazorServerDataGridSample/Pages/Index.razor
@@ -28,53 +28,64 @@
                 <br>
             }
 
-            <div class="d-flex my-2">
-                <div class="d-flex flex-column me-2">
-                    <label for="SlipNumber" class="form-label">伝票番号</label>
-                    <input @bind-value="SlipNumber" class="form-control" type="number" />
-                </div>
-                <br>
-                <div class="d-flex flex-column  me-2">
-                    <label for="RowNumber" class="form-label">行番号</label>
-                    <input @bind-value="RowNumber" class="form-control" type="number" />
-                </div>
-            </div>
-            <div class="d-flex my-2">
-                <div class="d-flex flex-column me-2">
-                    <label for="ItemCode" class="form-label">商品コード</label>
-                    <input @bind-value="ItemCode" class="form-control" type="text" />
-                </div>
-                <br>
-                <div class="d-flex flex-column  me-2">
-                    <label for="ItemName" class="form-label">商品名</label>
-                    <input @bind-value="ItemName" class="form-control" type="text" />
-                </div>
-            </div>
-            <div class="d-flex my-2">
-                <div class="d-flex flex-column  me-2">
-                    <label for="Quantity" class="form-label">数量</label>
-                    <input @bind-value="Quantity" class="form-control" type="number" />
-                </div>
-                <div class="d-flex flex-column  me-2">
-                    <label for="UnitPrice" class="form-label">単価</label>
-                    <input @bind-value="UnitPrice" class="form-control" type="number" />
-                </div>
-                <div class="d-flex flex-column  me-2">
-                    <label for="Amount" class="form-label">金額</label>
-                    <input @bind-value="Amount" class="form-control" type="number" disabled />
-                </div>
-                <div class="d-flex flex-column  me-2">
-                    <label for="SalesTax" class="form-label">消費税</label>
-                    <input @bind-value="SalesTax" class="form-control" type="number" disabled />
-                </div>
-            </div>
+            <EditForm Model="newSalesDetail" OnValidSubmit="AddNewDataButtonClick">
+                <DataAnnotationsValidator />
 
-            <br>
+                <div class="d-flex my-2">
+                    <div class="d-flex flex-column me-2">
+                        <label for="SlipNumber" class="form-label">伝票番号</label>
+                        <InputNumber @bind-Value="newSalesDetail.SlipNumber" class="form-control" />
+                        <ValidationMessage For="@(() => newSalesDetail.SlipNumber)" />
+                    </div>
+                    <br>
+                    <div class="d-flex flex-column  me-2">
+                        <label for="RowNumber" class="form-label">行番号</label>
+                        <InputNumber @bind-Value="newSalesDetail.RowNumber" class="form-control" />
+                        <ValidationMessage For="@(() => newSalesDetail.RowNumber)" />
+                    </div>
+                </div>
+                <div class="d-flex my-2">
+                    <div class="d-flex flex-column me-2">
+                        <label for="ItemCode" class="form-label">商品コード</label>
+                        <InputText @bind-Value="newSalesDetail.ItemCode" class="form-control" />
+                        <ValidationMessage For="@(() => newSalesDetail.ItemCode)" />
+                    </div>
+                    <br>
+                    <div class="d-flex flex-column  me-2">
+                        <label for="ItemName" class="form-label">商品名</label>
+                        <InputText @bind-Value="newSalesDetail.ItemName" class="form-control" />
+                        <ValidationMessage For="@(() => newSalesDetail.ItemName)" />
+                    </div>
+                </div>
+                <div class="d-flex my-2">
+                    <div class="d-flex flex-column  me-2">
+                        <label for="Quantity" class="form-label">数量</label>
+                        <InputNumber @bind-Value="newSalesDetail.Quantity" class="form-control" />
+                        <ValidationMessage For="@(() => newSalesDetail.Quantity)" />
+                    </div>
+                    <div class="d-flex flex-column  me-2">
+                        <label for="UnitPrice" class="form-label">単価</label>
+                        <InputNumber @bind-Value="newSalesDetail.UnitPrice" class="form-control" />
+                        <ValidationMessage For="@(() => newSalesDetail.UnitPrice)" />
+                    </div>
+                    <div class="d-flex flex-column  me-2">
+                        <label for="Amount" class="form-label">金額</label>
+                        <input value="@Amount" class="form-control" type="number" disabled />
+                    </div>
+                    <div class="d-flex flex-column  me-2">
+                        <label for="SalesTax" class="form-label">消費税</label>
+                        <input value="@SalesTax" class="form-control" type="number" disabled />
+                    </div>
+                </div>
 
-            <div class="d-flex bd-highlight mb-3">
-                <button class="btn btn-primary" @onclick="AddNewDataButtonClick">Add Data</button>
-                <button class="btn btn-secondary ms-auto p-2 bd-highlight" @onclick="UpdateDetailsDataButtonClick">Update Details</button>
-            </div>
+                <br>
+
+                <div class="d-flex bd-highlight mb-3">
+                    <button type="submit" class="btn btn-primary">Add Data</button>
+                    <button type="button" class="btn btn-secondary ms-auto p-2 bd-highlight" @onclick="UpdateDetailsDataButtonClick">Update Details</button>
+                </div>
+
+            </EditForm>
 
             <br>
 
@@ -245,46 +256,18 @@
     private IgbGrid? _grid;
 
     //新規データ登録用
-    public int SlipNumber { get; set; }
-
-    public int RowNumber { get; set; } = 1;
-
-    public string ItemCode { get; set; } = "S003";
-
-    public string ItemName { get; set; } = "商品3";
-
-    private decimal _quantity;
-    public decimal Quantity
-    {
-        set
+    private readonly SalesDetailViewModel newSalesDetail = new SalesDetailViewModel
         {
-            _quantity = value;
-            Amount = Math.Ceiling(Quantity * _unitPrice);
-            SalesTax = Math.Ceiling(Amount * 0.1M);
-        }
-        get
-        {
-            return _quantity;
-        }
-    }
-    public decimal _unitPrice = 0;
-    public decimal UnitPrice
-    {
-        set
-        {
-            _unitPrice = value;
-            Amount = Math.Ceiling(Quantity * _unitPrice);
-            SalesTax = Math.Ceiling(Amount * 0.1M);
-        }
-        get
-        {
-            return _unitPrice;
-        }
-    }
+            RowNumber = 1,
+            ItemCode = "S003",
+            ItemName = "商品3",
+            Quantity = 12,
+            UnitPrice = 535
+        };
 
-    public decimal Amount { get; set; } = 0;
+    public decimal Amount => Math.Ceiling(newSalesDetail.Quantity * newSalesDetail.UnitPrice);
 
-    public decimal SalesTax { get; set; } = 0;
+    public decimal SalesTax => Math.Ceiling(Amount * 0.1M);
 
     //エラーメッセージ
     private string message = "";
@@ -299,20 +282,14 @@
         message = "";
         errorMessage = "";
 
-        var newRow = new SalesDetailViewModel();
-        newRow.SlipNumber = SlipNumber;
-        newRow.RowNumber = RowNumber;
-        newRow.ItemCode = ItemCode;
-        newRow.ItemName = ItemName;
-        newRow.Quantity = Quantity;
-        newRow.UnitPrice = UnitPrice;
+        var newRow = newSalesDetail.Clone();
         newRow.Amount = Amount;
         newRow.SalesTax = SalesTax;
-
         _salesDetails.Add(newRow);
 
-        RowNumber++;
-        _grid?.NotifyInsertItem(_salesDetails, RowNumber, newRow);
+        _grid?.NotifyInsertItem(_salesDetails, _salesDetails.Count - 1, newRow);
+
+        newSalesDetail.RowNumber++;
     }
 
     //明細データの更新処理
@@ -360,11 +337,7 @@
         _salesDetails = SalesDetailService.GetDispAll().ToList();
 
         //伝票番号の最大値
-        SlipNumber = _salesDetails.Select(n => n.SlipNumber).DefaultIfEmpty(0).Max() + 1;
-
-        //数量、単価初期値
-        this.Quantity = 12;
-        this.UnitPrice = 535;
+        newSalesDetail.SlipNumber = _salesDetails.Select(n => n.SlipNumber).DefaultIfEmpty(0).Max() + 1;
     }
 
     /// <summary>
@@ -461,6 +434,4 @@
 
         await Task.CompletedTask;
     }
-
-
 }

--- a/BlazorServerDataGridSample/Pages/Index.razor.css
+++ b/BlazorServerDataGridSample/Pages/Index.razor.css
@@ -1,0 +1,4 @@
+::deep .validation-message {
+    font-size: 80%;
+    margin-top: 4px;
+}


### PR DESCRIPTION
IgbGrid のデモンストレーションという観点では直接の関係はないのですが、折角ですので、入力フォーム周りを Blazor 流儀に整理してみました。

- 入力画面の Razor コンポーネントに、個々の入力項目のプロパティ/フィールドを生やしてそれを input にバインドするのではなく、モデルオブジェクトを1個用意して (今回のコミットでは `newSalesDetail` フィールド)、そのモデルオブジェクトのプロパティをバインドします。
- Blazor 標準の `<EditForm>` コンポーネントでフォーム部分を構成し、および、`<DataAnnotationsValidator>` コンポーネントに入力検証を実施させることで、モデルオブジェクト型に付与された属性ベースで入力検証が行なわれるようにします。なお今回は、諸事情でデータエンティティ型 (このサンプルプログラムでは `SalesDetail` クラス) を直接 IgbGrid にバインドできないことから、ビューモデルに AutoMapper でマッピングせざるを得なかったため、この方式の恩恵にあまり預かれてませんが、本来ならば、データエンティティ型そのものないしはそこから派生や抱合したビューモデルでバインドすることで、UI 上の入力検証とデータベースのスキーマ構成 (最大文字数であるとか、null 許容するしないとか) を属性ベースで**一箇所で実装でき、UI 上の振る舞いとデータベース構造とが乖離しない**のが、この技法の本来の旨みであります。
- 入力検証でのエラー検出時、見た目を少しよくするために、素の `<input>` 要素ではなく、これをラップした `<InputText>` や `<InputNumber>` といった Blazor 標準の入力フォームコンポーネントに差し替えました。本質的な機能差はないのですが、入力検証エラー発生時に赤く表示するCSSクラスが自動で付与されるとか、今回はとくに使っていませんが、フォーム入力のダーティチェックなどが機能するようになります。

あと、`Amount` と `SalesTax` の自動計算をどこで実装するか (どのクラスで責任を持つか) はかなり迷ったのですが、迷った末に今回は、`Index.razo` コンポーネントの計算プロパティとして整理しました。なおこれらの項目は、計算プロパティ、すなわち読み取り専用でよいので、無理に `@bind-value` で双方向バインドせずに、`value="@式"` による単方向バインドでユーザーインターフェース上の `input` 要素上に表示するようにしています。

Blazor におけるフォーム入力 に関して、Microsoft 公式のドキュメントサイトは下記になりますが、

https://learn.microsoft.com/ja-jp/aspnet/core/blazor/forms-and-input-components?view=aspnetcore-7.0

他にも、IGJP の Blazor 入門オンデマンド技術トレーニングの「07. 入力検証を実装」動画でも、この `<EditForm>` を組み合わせた入力検証の実装について解説していますので (時間9分)、参考になれば幸いです。

https://app.quden.io/videos?videoId=62e2315cda16e5002dfb81d8
