### PR TITLE
SalesDetailService サービスの扱うエンティティ型を SalesDetailViewModel に変更

### DIFF
--- a/BlazorServerDataGridSample/Data/Models/SalesDetail.cs
+++ b/BlazorServerDataGridSample/Data/Models/SalesDetail.cs
@@ -1,34 +1,33 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace BlazorServerDataGridSample.Data.Models
+namespace BlazorServerDataGridSample.Data.Models;
+
+/// <summary>
+/// 売上明細モデル
+/// </summary>
+[Table("SalesDetails")]
+public class SalesDetail
 {
-    /// <summary>
-    /// 売上明細モデル
-    /// </summary>
-    [Table("SalesDetails")]
-    public class SalesDetail
-    {
-        [Key]
-        public int Id { get; set; }
+    [Key]
+    public int Id { get; set; }
 
-        public int SlipNumber { get; set; }
+    public int SlipNumber { get; set; }
 
-        public int RowNumber { get; set; }
+    public int RowNumber { get; set; }
 
-        public string ItemCode { get; set; } = "";
+    public string ItemCode { get; set; } = "";
 
-        public string ItemName { get; set; } = "";
+    public string ItemName { get; set; } = "";
 
-        public decimal Quantity { get; set; }
+    public decimal Quantity { get; set; }
 
-        public decimal UnitPrice { get; set; }
+    public decimal UnitPrice { get; set; }
 
-        public decimal Amount { get; set; }
+    public decimal Amount { get; set; }
 
-        public decimal SalesTax { get; set; }
+    public decimal SalesTax { get; set; }
 
-        [Timestamp]
-        public byte[]? TimeStamp { get; set; }
-    }
+    [Timestamp]
+    public byte[]? TimeStamp { get; set; }
 }

--- a/BlazorServerDataGridSample/Data/SampleDbContext.cs
+++ b/BlazorServerDataGridSample/Data/SampleDbContext.cs
@@ -1,36 +1,35 @@
 ﻿using BlazorServerDataGridSample.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
-namespace BlazorServerDataGridSample.Data
+namespace BlazorServerDataGridSample.Data;
+
+public class SampleDbContext : DbContext
 {
-    public class SampleDbContext : DbContext
+
+    public DbSet<SalesDetail> SalesDetails { get; set; }
+
+    public SampleDbContext(DbContextOptions<SampleDbContext> options) : base(options)
     {
+    }
 
-        public DbSet<SalesDetail> SalesDetails { get; set; }
-
-        public SampleDbContext(DbContextOptions<SampleDbContext> options) : base(options)
-        {
-        }
-
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<SalesDetail>()
-                .ToTable("SalesDetails");
-            modelBuilder.Entity<SalesDetail>()
-                .HasData(
-                    new SalesDetail
-                    {
-                        Id = 1,
-                        SlipNumber = 10001,
-                        RowNumber = 1,
-                        ItemCode = "S001",
-                        ItemName = "商品1",
-                        Quantity = 3,
-                        UnitPrice = 330,
-                        Amount = 990,
-                        SalesTax = 99
-                    }
-                );
-        }
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<SalesDetail>()
+            .ToTable("SalesDetails");
+        modelBuilder.Entity<SalesDetail>()
+            .HasData(
+                new SalesDetail
+                {
+                    Id = 1,
+                    SlipNumber = 10001,
+                    RowNumber = 1,
+                    ItemCode = "S001",
+                    ItemName = "商品1",
+                    Quantity = 3,
+                    UnitPrice = 330,
+                    Amount = 990,
+                    SalesTax = 99
+                }
+            );
     }
 }

--- a/BlazorServerDataGridSample/Data/ViewModels/ItemSearchResultViewModel.cs
+++ b/BlazorServerDataGridSample/Data/ViewModels/ItemSearchResultViewModel.cs
@@ -1,14 +1,13 @@
-﻿namespace BlazorServerDataGridSample.Data.ViewModels
+﻿namespace BlazorServerDataGridSample.Data.ViewModels;
+
+public class ItemSearchResultViewModel
 {
-    public class ItemSearchResultViewModel
-    {
-        public int RowIndex { get; set; }
+    public int RowIndex { get; set; }
 
-        public string? ItemCode { get; set; }
+    public string? ItemCode { get; set; }
 
-        public string? ItemName { get; set; }
+    public string? ItemName { get; set; }
 
-        public decimal UnitPrice { get; set; }
+    public decimal UnitPrice { get; set; }
 
-    }
 }

--- a/BlazorServerDataGridSample/Data/ViewModels/SalesDetailViewModel.cs
+++ b/BlazorServerDataGridSample/Data/ViewModels/SalesDetailViewModel.cs
@@ -1,51 +1,44 @@
 ﻿using System.ComponentModel.DataAnnotations;
-using System.Xml.Linq;
 
-namespace BlazorServerDataGridSample.Data.ViewModels
+namespace BlazorServerDataGridSample.Data.ViewModels;
+
+[CustomValidation(typeof(SalesDetailViewModel), "SalesDetailCheck")]
+public class SalesDetailViewModel
 {
+    [Display(Name = "Id")]
+    public int Id { get; set; }
 
+    [Display(Name = "伝票番号")]
+    public int SlipNumber { get; set; }
 
-    [CustomValidation(typeof(SalesDetailViewModel), "SalesDetailCheck")]
-    public class SalesDetailViewModel
+    [Display(Name = "行番号")]
+    public int RowNumber { get; set; }
+
+    [Display(Name = "商品コード")]
+    public string ItemCode { get; set; } = "";
+
+    [Display(Name = "商品名")]
+    public string ItemName { get; set; } = "";
+
+    [Display(Name = "数量")]
+    public decimal Quantity { get; set; }
+
+    [Display(Name = "単価")]
+    public decimal UnitPrice { get; set; }
+
+    [Display(Name = "金額")]
+    public decimal Amount { get; set; }
+
+    [Display(Name = "消費税")]
+    public decimal SalesTax { get; set; }
+
+    public static ValidationResult? SalesDetailCheck(SalesDetailViewModel model, ValidationContext context)
     {
-        [Display(Name = "Id")]
-        public int Id { get; set; }
-
-        [Display(Name = "伝票番号")]
-        public int SlipNumber { get; set; }
-
-        [Display(Name = "行番号")]
-        public int RowNumber { get; set; }
-
-        [Display(Name = "商品コード")]
-        public string ItemCode { get; set; } = "";
-
-        [Display(Name = "商品名")]
-        public string ItemName { get; set; } = "";
-
-        [Display(Name = "数量")]
-        public decimal Quantity { get; set; }
-
-        [Display(Name = "単価")]
-        public decimal UnitPrice { get; set; }
-
-        [Display(Name = "金額")]
-        public decimal Amount { get; set; }
-
-        [Display(Name = "消費税")]
-        public decimal SalesTax { get; set; }
-
-
-        public static ValidationResult? SalesDetailCheck(SalesDetailViewModel model, ValidationContext context)
+        if (model == null)
         {
-            if (model == null)
-            {
-                throw new NullReferenceException();
-            }
-
-            return ValidationResult.Success;
+            throw new NullReferenceException();
         }
 
-
+        return ValidationResult.Success;
     }
 }

--- a/BlazorServerDataGridSample/Pages/Index.razor
+++ b/BlazorServerDataGridSample/Pages/Index.razor
@@ -322,23 +322,9 @@
         message = "";
         errorMessage = "";
 
-        // Mapするモデルの設定
-        var config = new MapperConfiguration(cfg =>
-        {
-            cfg.CreateMap<SalesDetailViewModel, SalesDetail>();
-        });
-
-        // Mapperを作成
-        var mapper = config.CreateMapper();
-
-        // SalesDetailViewModelのデータがSalesDetailの型でマッピングされる
-        var salesData = _salesDetails
-            .Select(mapper.Map<SalesDetail>)
-            .ToList();
-
         try
         {
-            SalesDetailService.UpdateAll(salesData);
+            SalesDetailService.UpdateAll(_salesDetails);
         }
         catch (DbUpdateConcurrencyException ex)
         {
@@ -357,7 +343,7 @@
     protected override void OnInitialized()
     {
         //売上明細一覧データの取得
-        _salesDetails = SalesDetailService.GetDispAll().ToList();
+        _salesDetails = SalesDetailService.GetAll().ToList();
 
         //伝票番号の最大値
         SlipNumber = _salesDetails.Select(n => n.SlipNumber).DefaultIfEmpty(0).Max() + 1;

--- a/BlazorServerDataGridSample/Program.cs
+++ b/BlazorServerDataGridSample/Program.cs
@@ -2,8 +2,6 @@ using BlazorServerDataGridSample.Data;
 using BlazorServerDataGridSample.Repositories;
 using BlazorServerDataGridSample.Services;
 using IgniteUI.Blazor.Controls;
-using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Web;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -11,8 +9,6 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
-
-
 
 //DBŠÖ˜A
 builder.Services.AddDbContext<SampleDbContext>(options =>
@@ -26,7 +22,6 @@ builder.Services.AddScoped<ISalesDetailRepository, SalesDetailRepository>();
 
 //ServiceŠÖ˜A            
 builder.Services.AddScoped<ISalesDetailService, SalesDetailService>();
-
 
 //Ignite UI for Blazor
 builder.Services.AddIgniteUIBlazor(

--- a/BlazorServerDataGridSample/Program.cs
+++ b/BlazorServerDataGridSample/Program.cs
@@ -11,7 +11,7 @@ builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
 
 //DBŠÖ˜A
-builder.Services.AddDbContext<SampleDbContext>(options =>
+builder.Services.AddDbContextFactory<SampleDbContext>(options =>
 {
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"));
 });

--- a/BlazorServerDataGridSample/Repositories/DetailRepository.cs
+++ b/BlazorServerDataGridSample/Repositories/DetailRepository.cs
@@ -1,74 +1,71 @@
 ﻿using AutoMapper;
 using Microsoft.EntityFrameworkCore;
 
+namespace BlazorServerDataGridSample.Repositories;
 
-namespace BlazorServerDataGridSample.Repositories
+public class DetailRepository<TEntity> : IDetailRepository<TEntity> where TEntity : class
 {
-    public class DetailRepository<TEntity> : IDetailRepository<TEntity> where TEntity : class
+    protected readonly ILogger<IDetailRepository<TEntity>> _logger;
+
+    protected readonly DbContext _context;
+
+    protected readonly IMapper _mapper;
+
+    public DetailRepository(DbContext context, ILogger<IDetailRepository<TEntity>> logger)
     {
+        _context = context;
+        _logger = logger;
 
-        protected readonly ILogger<IDetailRepository<TEntity>> _logger;
-
-        protected readonly DbContext _context;
-        protected readonly IMapper _mapper;
-        public DetailRepository(DbContext context, ILogger<IDetailRepository<TEntity>> logger)
+        // Mapするモデルの設定
+        var config = new MapperConfiguration(cfg =>
         {
-            _context = context;
-            _logger = logger;
+            cfg.CreateMap<TEntity, TEntity>();
+        });
 
-            // Mapするモデルの設定
-            var config = new MapperConfiguration(cfg =>
-            {
-                cfg.CreateMap<TEntity, TEntity>();
-            });
+        // Mapperを作成
+        _mapper = config.CreateMapper();
+    }
 
-            // Mapperを作成
-            _mapper = config.CreateMapper();
+    public void Add(TEntity entity)
+    {
+        _context.Set<TEntity>().Add(entity);
+        _context.SaveChanges();
+        //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
+    }
 
-        }
+    public TEntity Get(int id)
+    {
+        return _context.Set<TEntity>().Find(id)!;
+    }
 
-        public void Add(TEntity entity)
+    public IEnumerable<TEntity> GetAll()
+    {
+        return _context.Set<TEntity>().ToList();
+    }
+
+    public void Remove(int id)
+    {
+        var entry = _context.Set<TEntity>().Find(id);
+        _context.Set<TEntity>().Remove(entry!);
+        _context.SaveChanges();
+        //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
+    }
+
+    public void Update(TEntity entity, int id)
+    {
+        var entry = _context.Set<TEntity>().Find(id);
+
+        _mapper.Map(entity, entry);
+
+        try
         {
-            _context.Set<TEntity>().Add(entity);
             _context.SaveChanges();
             //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
         }
-
-        public TEntity Get(int id)
+        catch (DbUpdateConcurrencyException ex)
         {
-            return _context.Set<TEntity>().Find(id)!;
-        }
-
-        public IEnumerable<TEntity> GetAll()
-        {
-            return _context.Set<TEntity>().ToList();
-        }
-
-        public void Remove(int id)
-        {
-            var entry = _context.Set<TEntity>().Find(id);
-            _context.Set<TEntity>().Remove(entry!);
-            _context.SaveChanges();
-            //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
-        }
-
-        public void Update(TEntity entity, int id)
-        {
-            var entry = _context.Set<TEntity>().Find(id);
-
-            _mapper.Map(entity, entry);
-
-            try
-            {
-                _context.SaveChanges();
-                //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
-            }
-            catch (DbUpdateConcurrencyException ex)
-            {
-                _logger.LogError(ex, ex.Message); // ログ出力等をここで実装
-                throw;
-            }
-
+            _logger.LogError(ex, ex.Message); // ログ出力等をここで実装
+            throw;
         }
     }
 }

--- a/BlazorServerDataGridSample/Repositories/IDetailRepository.cs
+++ b/BlazorServerDataGridSample/Repositories/IDetailRepository.cs
@@ -1,19 +1,18 @@
-﻿namespace BlazorServerDataGridSample.Repositories
+﻿namespace BlazorServerDataGridSample.Repositories;
+
+/// <summary>
+/// 明細入力用のRepositoryインターフェイス
+/// </summary>
+/// <typeparam name="TEntity"></typeparam>
+public interface IDetailRepository<TEntity> where TEntity : class
 {
-    /// <summary>
-    /// 明細入力用のRepositoryインターフェイス
-    /// </summary>
-    /// <typeparam name="TEntity"></typeparam>
-    public interface IDetailRepository<TEntity> where TEntity : class
-    {
-        TEntity Get(int id);
+    TEntity Get(int id);
 
-        IEnumerable<TEntity> GetAll();
+    IEnumerable<TEntity> GetAll();
 
-        void Add(TEntity entity);
+    void Add(TEntity entity);
 
-        void Update(TEntity entity, int id);
+    void Update(TEntity entity, int id);
 
-        void Remove(int id);
-    }
+    void Remove(int id);
 }

--- a/BlazorServerDataGridSample/Repositories/IMasterRepository.cs
+++ b/BlazorServerDataGridSample/Repositories/IMasterRepository.cs
@@ -1,16 +1,18 @@
-﻿namespace BlazorServerDataGridSample.Repositories
-{
-    /// <summary>
-    /// マスターメンテ用Repositoryインターフェイス
-    /// </summary>
-    /// <typeparam name="TEntity">モデルを指定する</typeparam>
-    public interface IMasterRepository<TEntity> where TEntity : class
-    {
-        TEntity Get(int id);
-        IEnumerable<TEntity> GetAll();
-        void Add(TEntity entity);
+﻿namespace BlazorServerDataGridSample.Repositories;
 
-        void Update(TEntity entity, int id);
-        void Remove(int id);
-    }
+/// <summary>
+/// マスターメンテ用Repositoryインターフェイス
+/// </summary>
+/// <typeparam name="TEntity">モデルを指定する</typeparam>
+public interface IMasterRepository<TEntity> where TEntity : class
+{
+    TEntity Get(int id);
+
+    IEnumerable<TEntity> GetAll();
+
+    void Add(TEntity entity);
+
+    void Update(TEntity entity, int id);
+
+    void Remove(int id);
 }

--- a/BlazorServerDataGridSample/Repositories/ISalesDetailRepository.cs
+++ b/BlazorServerDataGridSample/Repositories/ISalesDetailRepository.cs
@@ -1,9 +1,8 @@
 ﻿using BlazorServerDataGridSample.Data.Models;
 
-namespace BlazorServerDataGridSample.Repositories
+namespace BlazorServerDataGridSample.Repositories;
+
+public interface ISalesDetailRepository : IDetailRepository<SalesDetail>
 {
-    public interface ISalesDetailRepository : IDetailRepository<SalesDetail>
-    {
-        void UpdateAll(IList<SalesDetail> entities);
-    }
+    void UpdateAll(IList<SalesDetail> entities);
 }

--- a/BlazorServerDataGridSample/Repositories/MasterRepository.cs
+++ b/BlazorServerDataGridSample/Repositories/MasterRepository.cs
@@ -2,73 +2,72 @@
 using Microsoft.EntityFrameworkCore;
 
 
-namespace BlazorServerDataGridSample.Repositories
+namespace BlazorServerDataGridSample.Repositories;
+
+public class MasterRepository<TEntity> : IMasterRepository<TEntity> where TEntity : class
 {
-    public class MasterRepository<TEntity> : IMasterRepository<TEntity> where TEntity : class
+
+    private readonly ILogger<IMasterRepository<TEntity>> _logger;
+
+    protected readonly DbContext _context;
+
+    protected readonly IMapper _mapper;
+
+    public MasterRepository(DbContext context, ILogger<IMasterRepository<TEntity>> logger)
     {
+        _context = context;
+        _logger = logger;
 
-        private readonly ILogger<IMasterRepository<TEntity>> _logger;
-
-        protected readonly DbContext _context;
-        protected readonly IMapper _mapper;
-        public MasterRepository(DbContext context, ILogger<IMasterRepository<TEntity>> logger)
+        // Mapするモデルの設定
+        var config = new MapperConfiguration(cfg =>
         {
-            _context = context;
-            _logger = logger;
+            cfg.CreateMap<TEntity, TEntity>();
+        });
 
-            // Mapするモデルの設定
-            var config = new MapperConfiguration(cfg =>
-            {
-                cfg.CreateMap<TEntity, TEntity>();
-            });
+        // Mapperを作成
+        _mapper = config.CreateMapper();
+    }
 
-            // Mapperを作成
-            _mapper = config.CreateMapper();
+    public void Add(TEntity entity)
+    {
+        _context.Set<TEntity>().Add(entity);
+        _context.SaveChanges();
+        //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
+    }
 
-        }
+    public TEntity Get(int id)
+    {
+        return _context.Set<TEntity>().Find(id)!;
+    }
 
-        public void Add(TEntity entity)
+    public virtual IEnumerable<TEntity> GetAll()
+    {
+        return _context.Set<TEntity>().ToList();
+    }
+
+    public void Remove(int id)
+    {
+        var entry = _context.Set<TEntity>().Find(id);
+        _context.Set<TEntity>().Remove(entry!);
+        _context.SaveChanges();
+        //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
+    }
+
+    public void Update(TEntity entity, int id)
+    {
+        var entry = _context.Set<TEntity>().Find(id);
+
+        _mapper.Map(entity, entry);
+
+        try
         {
-            _context.Set<TEntity>().Add(entity);
             _context.SaveChanges();
             //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
         }
-
-        public TEntity Get(int id)
+        catch (DbUpdateConcurrencyException ex)
         {
-            return _context.Set<TEntity>().Find(id)!;
-        }
-
-        public virtual IEnumerable<TEntity> GetAll()
-        {
-            return _context.Set<TEntity>().ToList();
-        }
-
-        public void Remove(int id)
-        {
-            var entry = _context.Set<TEntity>().Find(id);
-            _context.Set<TEntity>().Remove(entry!);
-            _context.SaveChanges();
-            //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
-        }
-
-        public void Update(TEntity entity, int id)
-        {
-            var entry = _context.Set<TEntity>().Find(id);
-
-            _mapper.Map(entity, entry);
-
-            try
-            {
-                _context.SaveChanges();
-                //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
-            }
-            catch (DbUpdateConcurrencyException ex)
-            {
-                _logger.LogError(ex, ex.Message); // ログ出力等をここで実装
-                throw;
-            }
-
+            _logger.LogError(ex, ex.Message); // ログ出力等をここで実装
+            throw;
         }
     }
 }

--- a/BlazorServerDataGridSample/Repositories/SalesDetailRepository.cs
+++ b/BlazorServerDataGridSample/Repositories/SalesDetailRepository.cs
@@ -2,51 +2,44 @@
 using BlazorServerDataGridSample.Data.Models;
 using Microsoft.EntityFrameworkCore;
 
-namespace BlazorServerDataGridSample.Repositories
+namespace BlazorServerDataGridSample.Repositories;
+
+public class SalesDetailRepository : DetailRepository<SalesDetail>, ISalesDetailRepository
 {
-    public class SalesDetailRepository : DetailRepository<SalesDetail>, ISalesDetailRepository
+    public SalesDetailRepository(SampleDbContext context, ILogger<SalesDetailRepository> logger)
+        : base(context, logger)
     {
-        public SalesDetailRepository(SampleDbContext context, ILogger<SalesDetailRepository> logger)
-            : base(context, logger)
-        {
-
-        }
-
-        public SampleDbContext? SampleDbContext
-        {
-            get { return _context as SampleDbContext; }
-        }
-
-        public void UpdateAll(IList<SalesDetail> entities)
-        {
-            foreach (var item in entities)
-            {
-                if (item.Id != 0)
-                {
-                    var entry = _context.Set<SalesDetail>().Find(item.Id);
-                    _mapper.Map(item, entry);
-                }
-                else
-                {
-                    _context.Set<SalesDetail>().Add(item);
-                }
-
-            }
-
-
-
-            try
-            {
-                _context.SaveChanges();
-                //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
-            }
-            catch (DbUpdateConcurrencyException ex)
-            {
-                _logger.LogError(ex, ex.Message); // ログ出力等をここで実装
-                throw;
-            }
-
-        }
     }
 
+    public SampleDbContext? SampleDbContext
+    {
+        get { return _context as SampleDbContext; }
+    }
+
+    public void UpdateAll(IList<SalesDetail> entities)
+    {
+        foreach (var item in entities)
+        {
+            if (item.Id != 0)
+            {
+                var entry = _context.Set<SalesDetail>().Find(item.Id);
+                _mapper.Map(item, entry);
+            }
+            else
+            {
+                _context.Set<SalesDetail>().Add(item);
+            }
+        }
+
+        try
+        {
+            _context.SaveChanges();
+            //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            _logger.LogError(ex, ex.Message); // ログ出力等をここで実装
+            throw;
+        }
+    }
 }

--- a/BlazorServerDataGridSample/Repositories/SalesDetailRepository.cs
+++ b/BlazorServerDataGridSample/Repositories/SalesDetailRepository.cs
@@ -4,36 +4,32 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BlazorServerDataGridSample.Repositories;
 
-public class SalesDetailRepository : DetailRepository<SalesDetail>, ISalesDetailRepository
+public class SalesDetailRepository : DetailRepository<SampleDbContext, SalesDetail>, ISalesDetailRepository
 {
-    public SalesDetailRepository(SampleDbContext context, ILogger<SalesDetailRepository> logger)
+    public SalesDetailRepository(IDbContextFactory<SampleDbContext> context, ILogger<SalesDetailRepository> logger)
         : base(context, logger)
     {
     }
 
-    public SampleDbContext? SampleDbContext
-    {
-        get { return _context as SampleDbContext; }
-    }
-
     public void UpdateAll(IList<SalesDetail> entities)
     {
+        using var context = _contextFactory.CreateDbContext();
         foreach (var item in entities)
         {
             if (item.Id != 0)
             {
-                var entry = _context.Set<SalesDetail>().Find(item.Id);
+                var entry = context.Set<SalesDetail>().Find(item.Id);
                 _mapper.Map(item, entry);
             }
             else
             {
-                _context.Set<SalesDetail>().Add(item);
+                context.Set<SalesDetail>().Add(item);
             }
         }
 
         try
         {
-            _context.SaveChanges();
+            context.SaveChanges();
             //_context.SaveChangesAsync() //非同期処理の場合はこちらを利用した実装に変更してください。
         }
         catch (DbUpdateConcurrencyException ex)

--- a/BlazorServerDataGridSample/Services/IDetailService.cs
+++ b/BlazorServerDataGridSample/Services/IDetailService.cs
@@ -1,19 +1,20 @@
-﻿namespace BlazorServerDataGridSample.Services
+﻿namespace BlazorServerDataGridSample.Services;
+
+/// <summary>
+/// 明細入力用サービスインターフェース
+/// </summary>
+/// <typeparam name="TEntity"></typeparam>
+public interface IDetailService<TEntity>
 {
-    /// <summary>
-    /// 明細入力用サービスインターフェース
-    /// </summary>
-    /// <typeparam name="TEntity"></typeparam>
-    public interface IDetailService<TEntity>
-    {
-        TEntity Get(int id);
-        IEnumerable<TEntity> GetAll();
-        void Add(TEntity entity);
+    TEntity Get(int id);
 
-        void Update(TEntity entity, int id);
+    IEnumerable<TEntity> GetAll();
 
-        void UpdateAll(IList<TEntity> entities);
+    void Add(TEntity entity);
 
-        void Remove(int id);
-    }
+    void Update(TEntity entity, int id);
+
+    void UpdateAll(IList<TEntity> entities);
+
+    void Remove(int id);
 }

--- a/BlazorServerDataGridSample/Services/IMasterService.cs
+++ b/BlazorServerDataGridSample/Services/IMasterService.cs
@@ -1,16 +1,18 @@
-﻿namespace BlazorServerDataGridSample.Services
-{
-    /// <summary>
-    /// マスター制御用サービスインターフェース
-    /// </summary>
-    /// <typeparam name="TEntity"></typeparam>
-    public interface IMasterService<TEntity>
-    {
-        TEntity Get(int id);
-        IEnumerable<TEntity> GetAll();
-        void Add(TEntity entity);
+﻿namespace BlazorServerDataGridSample.Services;
 
-        void Update(TEntity entity, int id);
-        void Remove(int id);
-    }
+/// <summary>
+/// マスター制御用サービスインターフェース
+/// </summary>
+/// <typeparam name="TEntity"></typeparam>
+public interface IMasterService<TEntity>
+{
+    TEntity Get(int id);
+
+    IEnumerable<TEntity> GetAll();
+
+    void Add(TEntity entity);
+
+    void Update(TEntity entity, int id);
+
+    void Remove(int id);
 }

--- a/BlazorServerDataGridSample/Services/ISalesDetailService.cs
+++ b/BlazorServerDataGridSample/Services/ISalesDetailService.cs
@@ -1,10 +1,9 @@
 ﻿using BlazorServerDataGridSample.Data.Models;
 using BlazorServerDataGridSample.Data.ViewModels;
 
-namespace BlazorServerDataGridSample.Services
+namespace BlazorServerDataGridSample.Services;
+
+interface ISalesDetailService : IDetailService<SalesDetail>
 {
-    interface ISalesDetailService : IDetailService<SalesDetail>
-    {
-        IList<SalesDetailViewModel> GetDispAll();
-    }
+    IList<SalesDetailViewModel> GetDispAll();
 }

--- a/BlazorServerDataGridSample/Services/ISalesDetailService.cs
+++ b/BlazorServerDataGridSample/Services/ISalesDetailService.cs
@@ -3,7 +3,6 @@ using BlazorServerDataGridSample.Data.ViewModels;
 
 namespace BlazorServerDataGridSample.Services;
 
-interface ISalesDetailService : IDetailService<SalesDetail>
+interface ISalesDetailService : IDetailService<SalesDetailViewModel>
 {
-    IList<SalesDetailViewModel> GetDispAll();
 }

--- a/BlazorServerDataGridSample/Services/SalesDetailService.cs
+++ b/BlazorServerDataGridSample/Services/SalesDetailService.cs
@@ -9,51 +9,37 @@ public class SalesDetailService : ISalesDetailService
 {
     private readonly ISalesDetailRepository _SalesDetailRepository;
 
+    private static readonly IMapper _mapper = new MapperConfiguration(cfg =>
+    {
+        cfg.CreateMap<SalesDetail, SalesDetailViewModel>();
+        cfg.CreateMap<SalesDetailViewModel, SalesDetail>();
+    }).CreateMapper();
+
     public SalesDetailService(ISalesDetailRepository SalesDetailRepository)
     {
         _SalesDetailRepository = SalesDetailRepository;
     }
 
-    public void Add(SalesDetail entity)
+    public void Add(SalesDetailViewModel entity)
     {
-        _SalesDetailRepository.Add(entity);
+        _SalesDetailRepository.Add(_mapper.Map<SalesDetail>(entity));
     }
 
-    public SalesDetail Get(int id)
+    public SalesDetailViewModel Get(int id)
     {
-        return _SalesDetailRepository.Get(id);
+        return _mapper.Map<SalesDetailViewModel>( _SalesDetailRepository.Get(id));
     }
 
     /// <summary>
     /// ユーザーデータを全件取得
     /// </summary>
     /// <returns></returns>
-    public IEnumerable<SalesDetail> GetAll()
+    public IEnumerable<SalesDetailViewModel> GetAll()
     {
-        return _SalesDetailRepository.GetAll();
-    }
-
-    public IList<SalesDetailViewModel> GetDispAll()
-    {
-        var salesDetails = GetAll();
-        List<SalesDetailViewModel> salesDetailViewModels = new();
-
-        // Mapするモデルの設定
-        var config = new MapperConfiguration(cfg =>
-        {
-            cfg.CreateMap<SalesDetail, SalesDetailViewModel>();
-        });
-
-        // Mapperを作成
-        var mapper = config.CreateMapper();
-
-        foreach (var item in salesDetails)
-        {
-            var newItem = mapper.Map<SalesDetailViewModel>(item);
-            salesDetailViewModels.Add(newItem);
-        }
-
-        return salesDetailViewModels;
+        var salesDetails = _SalesDetailRepository.GetAll();
+        return salesDetails
+            .Select(_mapper.Map<SalesDetailViewModel>)
+            .ToArray();
     }
 
     public void Remove(int id)
@@ -61,13 +47,13 @@ public class SalesDetailService : ISalesDetailService
         _SalesDetailRepository.Remove(id);
     }
 
-    public void Update(SalesDetail entity, int id)
+    public void Update(SalesDetailViewModel entity, int id)
     {
-        _SalesDetailRepository.Update(entity, id);
+        _SalesDetailRepository.Update(_mapper.Map<SalesDetail>(entity), id);
     }
 
-    public void UpdateAll(IList<SalesDetail> entities)
+    public void UpdateAll(IList<SalesDetailViewModel> entities)
     {
-        _SalesDetailRepository.UpdateAll(entities);
+        _SalesDetailRepository.UpdateAll(entities.Select(_mapper.Map<SalesDetail>).ToList());
     }
 }

--- a/BlazorServerDataGridSample/Services/SalesDetailService.cs
+++ b/BlazorServerDataGridSample/Services/SalesDetailService.cs
@@ -2,76 +2,72 @@
 using BlazorServerDataGridSample.Data.Models;
 using BlazorServerDataGridSample.Data.ViewModels;
 using BlazorServerDataGridSample.Repositories;
-using System;
-using System.Collections.Generic;
 
-namespace BlazorServerDataGridSample.Services
+namespace BlazorServerDataGridSample.Services;
+
+public class SalesDetailService : ISalesDetailService
 {
-    public class SalesDetailService : ISalesDetailService
+    private readonly ISalesDetailRepository _SalesDetailRepository;
+
+    public SalesDetailService(ISalesDetailRepository SalesDetailRepository)
     {
-        private readonly ISalesDetailRepository _SalesDetailRepository;
+        _SalesDetailRepository = SalesDetailRepository;
+    }
 
-        public SalesDetailService(ISalesDetailRepository SalesDetailRepository)
+    public void Add(SalesDetail entity)
+    {
+        _SalesDetailRepository.Add(entity);
+    }
+
+    public SalesDetail Get(int id)
+    {
+        return _SalesDetailRepository.Get(id);
+    }
+
+    /// <summary>
+    /// ユーザーデータを全件取得
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<SalesDetail> GetAll()
+    {
+        return _SalesDetailRepository.GetAll();
+    }
+
+    public IList<SalesDetailViewModel> GetDispAll()
+    {
+        var salesDetails = GetAll();
+        List<SalesDetailViewModel> salesDetailViewModels = new();
+
+        // Mapするモデルの設定
+        var config = new MapperConfiguration(cfg =>
         {
-            _SalesDetailRepository = SalesDetailRepository;
+            cfg.CreateMap<SalesDetail, SalesDetailViewModel>();
+        });
+
+        // Mapperを作成
+        var mapper = config.CreateMapper();
+
+        foreach (var item in salesDetails)
+        {
+            var newItem = mapper.Map<SalesDetailViewModel>(item);
+            salesDetailViewModels.Add(newItem);
         }
 
-        public void Add(SalesDetail entity)
-        {
-            _SalesDetailRepository.Add(entity);
-        }
+        return salesDetailViewModels;
+    }
 
-        public SalesDetail Get(int id)
-        {
-            return _SalesDetailRepository.Get(id);
-        }
+    public void Remove(int id)
+    {
+        _SalesDetailRepository.Remove(id);
+    }
 
-        /// <summary>
-        /// ユーザーデータを全件取得
-        /// </summary>
-        /// <returns></returns>
-        public IEnumerable<SalesDetail> GetAll()
-        {
-            return _SalesDetailRepository.GetAll();
-        }
+    public void Update(SalesDetail entity, int id)
+    {
+        _SalesDetailRepository.Update(entity, id);
+    }
 
-        public IList<SalesDetailViewModel> GetDispAll()
-        {
-            var salesDetails = GetAll();
-            List<SalesDetailViewModel> salesDetailViewModels = new();
-
-            // Mapするモデルの設定
-            var config = new MapperConfiguration(cfg =>
-            {
-                cfg.CreateMap<SalesDetail, SalesDetailViewModel>();
-            });
-
-            // Mapperを作成
-            var mapper = config.CreateMapper();
-
-            foreach (var item in salesDetails)
-            {
-                var newItem = mapper.Map<SalesDetailViewModel>(item);
-                salesDetailViewModels.Add(newItem);
-            }
-
-            return salesDetailViewModels;
-        }
-
-        public void Remove(int id)
-        {
-            _SalesDetailRepository.Remove(id);
-        }
-
-        public void Update(SalesDetail entity, int id)
-        {
-            _SalesDetailRepository.Update(entity, id);
-        }
-
-        public void UpdateAll(IList<SalesDetail> entities)
-        {
-            _SalesDetailRepository.UpdateAll(entities);
-        }
-
+    public void UpdateAll(IList<SalesDetail> entities)
+    {
+        _SalesDetailRepository.UpdateAll(entities);
     }
 }


### PR DESCRIPTION
(このプルリクエストは、先行するプルリクエスト #9, #10 の上に積み重ねています)

折角 SalesDetailService サービスクラスにエンティティの取り扱いを移譲しているのに、Index.razor 側に、SalesDetail と SalesDetailViewModel との変換処理が実装されているなど、SalesDetail 型への参照が Index.razor に漏れ出ておりました。
そもそも SalesDetailService サービスクラスが扱うエンティティ型を SalesDetailViewModel にしておけば設計的にもスッキリし、Index.razor も SalesDetail 型など相手にせずに SalesDetailViewModel 型だけ見ていればよくなります。

ということで、そのように実装を変更してみました。変更差分は下記リンクのほうが見やすいかと思います。

https://github.com/yoshi1220/BlazorServerIgniteUIDataGridSample/commit/0e12cf0101f902fad29bbbd07dadac4b4c0c3613

以上、ご検討よろしくお願いします。